### PR TITLE
Clarify day/night horizon logic

### DIFF
--- a/horary/backend/horary_engine/engine.py
+++ b/horary/backend/horary_engine/engine.py
@@ -1295,10 +1295,10 @@ class EnhancedTraditionalAstrologicalCalculator:
         if sign not in triplicity_rulers:
             return 0
             
-        # Determine if it's day or night (Sun above or below horizon)
-        # Day = Sun in houses 7-12 (below horizon), Night = Sun in houses 1-6 (above horizon)
+        # Determine if it's day or night based on Sun's position relative to the horizon
+        # Day = Sun in houses 7-12 (above horizon), Night = Sun in houses 1-6 (below horizon)
         sun_house = sun_pos.house
-        is_day = sun_house in [7, 8, 9, 10, 11, 12]  # Houses below horizon = day
+        is_day = sun_house in [7, 8, 9, 10, 11, 12]  # Sun above horizon = day chart
         sect = "day" if is_day else "night"
         
         if triplicity_rulers[sign][sect] == planet:
@@ -1333,7 +1333,7 @@ class EnhancedTraditionalAstrologicalCalculator:
         
         # Determine if Sun is above horizon (day) or below (night)
         sun_house = self._calculate_house_position(sun_pos.longitude, houses)
-        is_day = sun_house in [7, 8, 9, 10, 11, 12]  # Houses below horizon = day
+        is_day = sun_house in [7, 8, 9, 10, 11, 12]  # Sun above horizon = day chart
         
         # Traditional sect assignments
         diurnal_planets = [Planet.SUN, Planet.JUPITER, Planet.SATURN]  
@@ -1432,7 +1432,10 @@ class EnhancedTraditionalAstrologicalCalculator:
         return Sign.PISCES
     
     def _calculate_house_position(self, longitude: float, houses: List[float]) -> int:
-        """Calculate house position"""
+        """Return house index with horizon orientation.
+
+        Houses 7-12 are above the horizon (day); houses 1-6 lie below (night).
+        """
         longitude = longitude % 360
         
         for i in range(12):

--- a/horary/backend/horary_engine/reception.py
+++ b/horary/backend/horary_engine/reception.py
@@ -61,7 +61,7 @@ class TraditionalReceptionCalculator:
         # Determine day/night for triplicity calculations
         sun_pos = chart.planets[Planet.SUN]
         sun_house = self._calculate_house_position(sun_pos.longitude, chart.houses)
-        is_day = sun_house in [7, 8, 9, 10, 11, 12]  # Sun below horizon = day chart
+        is_day = sun_house in [7, 8, 9, 10, 11, 12]  # Sun above horizon = day chart
 
         # Check all dignity types for both directions
         reception_1_to_2 = self._check_all_dignities(planet1, pos2, is_day)
@@ -395,7 +395,10 @@ class TraditionalReceptionCalculator:
         return f"{receiving.value} receives {received.value} by {dignity_label}"
 
     def _calculate_house_position(self, longitude: float, houses: List[float]) -> int:
-        """Helper method for house calculation"""
+        """Return house index with horizon orientation.
+
+        Houses 7-12 are above the horizon (day); houses 1-6 lie below (night).
+        """
         longitude = longitude % 360
 
         for i in range(12):


### PR DESCRIPTION
## Summary
- Fix comments to note Sun above horizon indicates a day chart
- Document house ranges: houses 7-12 above horizon (day), 1-6 below (night)

## Testing
- `cd horary/backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68beaff2e6c083248ff6eba4e3f14af6