### PR TITLE
Enforce aspect degree limits in translation and collection

### DIFF
--- a/horary/backend/horary_constants.yaml
+++ b/horary/backend/horary_constants.yaml
@@ -119,6 +119,7 @@ translation:
 collection:
   require_collector_dignity: true # Collector should be dignified
   minimum_dignity_score: 0       # Minimum dignity for valid collection
+  max_application_deg: 15.0       # Maximum degrees to exact for applying aspect
 
 confidence:
   # Base confidence levels

--- a/horary/backend/tests/test_degree_limits.py
+++ b/horary/backend/tests/test_degree_limits.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import importlib.util
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault('HORARY_CONFIG_SKIP_VALIDATION', 'true')
+base_dir = Path(__file__).resolve().parents[1]
+sys.path.append(str(base_dir))
+
+pkg = types.ModuleType("horary_engine")
+pkg.__path__ = [str(base_dir / "horary_engine")]
+sys.modules["horary_engine"] = pkg
+spec = importlib.util.spec_from_file_location(
+    "horary_engine.perfection_core", base_dir / "horary_engine" / "perfection_core.py"
+)
+perfection_core = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = perfection_core
+spec.loader.exec_module(perfection_core)
+
+EventDetector = perfection_core.EventDetector
+from models import Planet, Aspect
+
+
+def test_find_applying_aspect_respects_max_degree():
+    ed = EventDetector()
+    ed.timing = SimpleNamespace(
+        when_exact_in_days=lambda p1, p2, aspect, chart: 10.0,
+        _get_daily_motion=lambda pos: pos.speed,
+    )
+    chart = SimpleNamespace(planets={
+        Planet.MERCURY: SimpleNamespace(speed=1.0),
+        Planet.MARS: SimpleNamespace(speed=0.6),
+    })
+    # Close aspect within 5 degrees
+    assert ed._find_applying_aspect(chart, Planet.MERCURY, Planet.MARS, 30, max_degree=5.0)
+    # Wide aspect beyond 5 degrees
+    chart.planets[Planet.MARS].speed = 0.4
+    assert ed._find_applying_aspect(chart, Planet.MERCURY, Planet.MARS, 30, max_degree=5.0) is None
+
+
+def test_find_separating_aspect_respects_max_degree():
+    ed = EventDetector()
+    ed.timing = SimpleNamespace(_get_daily_motion=lambda pos: pos.speed)
+    # Close separation within 10 degrees
+    chart = SimpleNamespace(planets={
+        Planet.MERCURY: SimpleNamespace(longitude=0.0, speed=1.0),
+        Planet.MARS: SimpleNamespace(longitude=5.0, speed=2.0),
+    })
+    assert ed._find_separating_aspect(chart, Planet.MERCURY, Planet.MARS, 30, max_degree=10.0)
+    # Wide separation beyond 10 degrees
+    chart.planets[Planet.MARS].longitude = 12.0
+    assert ed._find_separating_aspect(chart, Planet.MERCURY, Planet.MARS, 30, max_degree=10.0) is None

--- a/horary/backend/tests/test_translation_config.py
+++ b/horary/backend/tests/test_translation_config.py
@@ -44,17 +44,21 @@ def setup_env(monkeypatch, *, sep_timing=-1.0, app_timing=1.0,
         'target': quesited,
     }
 
-    def fake_find_separating_aspect(self, chart, p1, p2, window_days):
+    def fake_find_separating_aspect(self, chart, p1, p2, window_days, max_degree=None):
         if p1 == translator and p2 in (querent, quesited):
+            if max_degree is not None and sep_event['degrees_from_exact'] > max_degree:
+                return None
             return sep_event
         return None
 
-    def fake_find_applying_aspect(self, chart, p1, p2, window_days):
+    def fake_find_applying_aspect(self, chart, p1, p2, window_days, max_degree=None):
         if p1 == translator and p2 in (querent, quesited):
+            if max_degree is not None and app_event['degrees_to_exact'] > max_degree:
+                return None
             return app_event
         return None
 
-    def fake_find_earliest_application(self, chart, planet, window_days, exclude=None):
+    def fake_find_earliest_application(self, chart, planet, window_days, exclude=None, max_degree=None):
         return {'target': quesited, 'timing': app_timing}
 
     def fake_get_cached_reception(self, chart, p1, p2):
@@ -73,6 +77,8 @@ def setup_env(monkeypatch, *, sep_timing=-1.0, app_timing=1.0,
     ed.config.translation.require_proper_sequence = require_proper_sequence
     ed.config.translation.max_separation_deg = 10.0
     ed.config.translation.max_application_deg = 15.0
+
+    ed.timing = SimpleNamespace(_get_daily_motion=lambda pos: getattr(pos, 'daily_motion', 0))
 
     chart = SimpleNamespace(planets={
         translator: SimpleNamespace(daily_motion=1.0),


### PR DESCRIPTION
## Summary
- Reject separating/applying aspect candidates that exceed configured degree limits.
- Respect degree limits across translation and collection workflows via new `max_degree` checks.
- Add configuration for collection degree limit and tests covering wide vs close aspect scenarios.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68beb338657c83249dfecead01610bd2